### PR TITLE
se implementa limit para la cantidad de post

### DIFF
--- a/controllers/posts.js
+++ b/controllers/posts.js
@@ -88,23 +88,31 @@ function updatePost(req, res, next){ // OK
 }
 
 
-// Topic Filter
+// Topic Filter, Múltiple filter, requires an array in body with the list of topics to show
 function filterPost(req, res, next){ //OK
 
-    let topic = req.params.topic;
+    let topics = req.body;
 
     Post.aggregate([
         {
             '$match': {
-                'topic': topic
+                'topic' : { '$in' : topics.topics}
             }
-        }
+        },
+
+        {
+            '$limit': topics.limit
+          }
     ])
     .then(r => {
         res.status(200).send(r)
     })
     .catch(next);
 }
+
+// For multiple topics could be possible to use the pipeline function in 
+
+
 
 // Specific Qty of post
 // Esto sería parte del front???
@@ -118,3 +126,18 @@ module.exports = {
     updatePost,
     filterPost
 }
+
+
+
+/*
+Normal creation of a user:
+
+{
+	"title": "This post is created by another user",
+	"description": "Test post",
+	"topic": "HTML",
+	"author": "6147eed99e437ce2098a5f88"
+}
+
+
+*/

--- a/routes/posts.js
+++ b/routes/posts.js
@@ -12,7 +12,7 @@ const {
 
 router.get('/', getPost);
 router.get('/list/:author', getUserPost);
-router.get('/topics/:topic', filterPost);
+router.get('/topics', filterPost);
 router.get('/:id', getPost);
 router.post('/', createPost);
 router.delete('/:id', deletePost)


### PR DESCRIPTION
Se agrega la funcionalidad de enviar en el body la cantidad de post a listar así como los temas a filtrar (se puede seleccionar ver múltiples temas, por ejemplo, "ver todos los post que tengan por tema HTML o JavaScript").


Queda pendiente evaluar la posibilidad de agregar múltiples temas a un post para no tenerlo tan limitado. 